### PR TITLE
Fix StackOverflowError caused by infinite loop.

### DIFF
--- a/src/main/java/snw/kookbc/impl/plugin/SimplePluginManager.java
+++ b/src/main/java/snw/kookbc/impl/plugin/SimplePluginManager.java
@@ -67,7 +67,7 @@ public class SimplePluginManager implements PluginManager {
 
     @Override
     public @NotNull Plugin loadPlugin(File file) throws InvalidPluginException {
-        Plugin plugin = new SimplePluginManager(client).loadPlugin(file);
+        Plugin plugin = new SimplePluginClassLoader(client).loadPlugin(file);
         PluginDescription description = plugin.getDescription();
         int diff = getVersionDifference(description.getApiVersion(), client.getCore().getAPIVersion());
         if (diff == -1) {


### PR DESCRIPTION
# KookBC Pull Request

## KookBC 程序的漏洞修复

修复了 SimplePluginManager#loadPlugin 中的无限递归。