### PR TITLE
修复系统消息added_channel时可能出现的level空指针异常

### DIFF
--- a/src/main/java/snw/kookbc/impl/entity/builder/EntityBuilder.java
+++ b/src/main/java/snw/kookbc/impl/entity/builder/EntityBuilder.java
@@ -104,8 +104,7 @@ public class EntityBuilder {
         Category parent = ("".equals(parentId) || "0".equals(parentId)) ? null : (Category) client.getStorage().getChannel(parentId);
 
         boolean isPermSync = object.get("permission_sync").getAsInt() != 0;
-        int level = object.get("level").getAsInt();
-
+        Integer level = object.get("level").isJsonNull() ? 0 : object.get("level").getAsInt();
         // rpo parse
         Collection<Channel.RolePermissionOverwrite> rpo = new ArrayList<>();
         for (JsonElement element : object.get("permission_overwrites").getAsJsonArray()) {

--- a/src/main/java/snw/kookbc/impl/entity/channel/CategoryImpl.java
+++ b/src/main/java/snw/kookbc/impl/entity/channel/CategoryImpl.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public class CategoryImpl extends ChannelImpl implements Category {
     private final Collection<Channel> channels = new HashSet<>();
 
-    public CategoryImpl(KBCClient client, String id, User master, Guild guild, Category parent, boolean permSync, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, int level, String name) {
+    public CategoryImpl(KBCClient client, String id, User master, Guild guild, Category parent, boolean permSync, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, Integer level, String name) {
         super(client, id, master, guild, permSync, parent, name, rpo, upo, level);
     }
 

--- a/src/main/java/snw/kookbc/impl/entity/channel/ChannelImpl.java
+++ b/src/main/java/snw/kookbc/impl/entity/channel/ChannelImpl.java
@@ -120,7 +120,7 @@ public abstract class ChannelImpl implements Channel {
     }
 
     @Override
-    public void setLevel(Integer level) {
+    public void setLevel(int level) {
         Map<String, Object> body = new MapBuilder()
                 .put("channel_id", getId())
                 .put("level", level)

--- a/src/main/java/snw/kookbc/impl/entity/channel/ChannelImpl.java
+++ b/src/main/java/snw/kookbc/impl/entity/channel/ChannelImpl.java
@@ -46,9 +46,9 @@ public abstract class ChannelImpl implements Channel {
     private boolean permSync;
     private Category parent;
     private String name;
-    private int level;
+    private Integer level;
 
-    public ChannelImpl(KBCClient client, String id, User master, Guild guild, boolean permSync, Category parent, String name, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, int level) {
+    public ChannelImpl(KBCClient client, String id, User master, Guild guild, boolean permSync, Category parent, String name, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, Integer level) {
         this.client = client;
         this.id = id;
         this.master = master;
@@ -115,12 +115,12 @@ public abstract class ChannelImpl implements Channel {
     }
 
     @Override
-    public int getLevel() {
+    public Integer getLevel() {
         return level;
     }
 
     @Override
-    public void setLevel(int level) {
+    public void setLevel(Integer level) {
         Map<String, Object> body = new MapBuilder()
                 .put("channel_id", getId())
                 .put("level", level)

--- a/src/main/java/snw/kookbc/impl/entity/channel/TextChannelImpl.java
+++ b/src/main/java/snw/kookbc/impl/entity/channel/TextChannelImpl.java
@@ -44,7 +44,7 @@ public class TextChannelImpl extends ChannelImpl implements TextChannel {
     private int chatLimitTime;
     private String topic;
 
-    public TextChannelImpl(KBCClient client, String id, User master, Guild guild, boolean permSync, Category parent, String name, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, int level, int chatLimitTime, String topic) {
+    public TextChannelImpl(KBCClient client, String id, User master, Guild guild, boolean permSync, Category parent, String name, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, Integer level, int chatLimitTime, String topic) {
         super(client, id, master, guild, permSync, parent, name, rpo, upo, level);
         this.chatLimitTime = chatLimitTime;
         this.topic = topic;

--- a/src/main/java/snw/kookbc/impl/entity/channel/VoiceChannelImpl.java
+++ b/src/main/java/snw/kookbc/impl/entity/channel/VoiceChannelImpl.java
@@ -36,7 +36,7 @@ public class VoiceChannelImpl extends ChannelImpl implements VoiceChannel {
     private boolean passwordProtected;
     private int maxSize;
 
-    public VoiceChannelImpl(KBCClient client, String id, User master, Guild guild, boolean permSync, Category parent, String name, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, int level, boolean passwordProtected, int maxSize) {
+    public VoiceChannelImpl(KBCClient client, String id, User master, Guild guild, boolean permSync, Category parent, String name, Collection<RolePermissionOverwrite> rpo, Collection<UserPermissionOverwrite> upo, Integer level, boolean passwordProtected, int maxSize) {
         super(client, id, master, guild, permSync, parent, name, rpo, upo, level);
         this.passwordProtected = passwordProtected;
         this.maxSize = maxSize;


### PR DESCRIPTION
# KookBC Pull Request

您的 Fork 仓库地址:
https://github.com/cnluminous/KookBC

## KookBC 程序的漏洞修复
判断level是否为null，为null则填充 0

**此bug目前没有什么实质性影响，但是会在后台报错影响调试**

## 报错
[Event Executor/ERROR]: Event payload: Frame{type=EVENT, sn=2, d={"channel_type":"GROUP","type":255,"target_id":"5843447190838204","author_id":"1","content":"[系统消息]","extra":{"type":"added_channel","body":{"id":"1166952661165749","name":"工单1675591393437","user_id":"305357727","guild_id":"5843447190838204","is_category":0,"parent_id":"2938579928701603",**"level":null**,"slow_mode":0,"topic":"","type":1,"permission_overwrites":[{"role_id":0,"allow":0,"deny":2048}],"permission_users":[],"permission_sync":1,"mode":null,"has_password":false,"last_msg_content":"欢迎来到\"工单1675591393437\"","last_msg_id":""}},"msg_id":"d671d73f-7943-4705-bded-e45a229bba7b","msg_timestamp":1675588251865,"nonce":"","from_type":1}}
[Event Executor/ERROR]: java.lang.UnsupportedOperationException: JsonNull
[Event Executor/ERROR]: 	at com.google.gson.JsonElement.getAsInt(JsonElement.java:239)
[Event Executor/ERROR]: 	at snw.kookbc.impl.entity.builder.EntityBuilder.buildChannel(EntityBuilder.java:107)
[Event Executor/ERROR]: 	at snw.kookbc.impl.event.EventFactory.getEvent(EventFactory.java:138)
[Event Executor/ERROR]: 	at snw.kookbc.impl.network.ListenerImpl.event0(ListenerImpl.java:136)
[Event Executor/ERROR]: 	at snw.kookbc.impl.network.ListenerImpl.event(ListenerImpl.java:100)
[Event Executor/ERROR]: 	at snw.kookbc.impl.network.ListenerImpl.lambda$executeEvent$0(ListenerImpl.java:61)
[Event Executor/ERROR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[Event Executor/ERROR]: 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[Event Executor/ERROR]: 	at java.base/java.lang.Thread.run(Thread.java:833)