### PR TITLE
Use NetworkClient.postContent() instead of NetworkClient.post() in …

### DIFF
--- a/src/main/java/snw/kookbc/impl/entity/ReactionImpl.java
+++ b/src/main/java/snw/kookbc/impl/entity/ReactionImpl.java
@@ -58,7 +58,7 @@ public class ReactionImpl implements Reaction {
                 .put("msg_id", getMessageId())
                 .put("emoji_id", emoji.getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_REMOVE.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_REMOVE.toFullURL(), body);
     }
 
     @Override

--- a/src/main/java/snw/kookbc/impl/message/PrivateMessageImpl.java
+++ b/src/main/java/snw/kookbc/impl/message/PrivateMessageImpl.java
@@ -41,7 +41,7 @@ public class PrivateMessageImpl extends MessageImpl implements PrivateMessage {
                 .put("msg_id", getId())
                 .put("emoji", emoji.getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.USER_CHAT_MESSAGE_REACTION_ADD.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.USER_CHAT_MESSAGE_REACTION_ADD.toFullURL(), body);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class PrivateMessageImpl extends MessageImpl implements PrivateMessage {
                 .put("msg_id", getId())
                 .put("emoji", emoji.getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.USER_CHAT_MESSAGE_REACTION_REMOVE.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.USER_CHAT_MESSAGE_REACTION_REMOVE.toFullURL(), body);
     }
 
     @Override
@@ -78,6 +78,6 @@ public class PrivateMessageImpl extends MessageImpl implements PrivateMessage {
         Map<String, Object> body = new MapBuilder()
                 .put("msg_id", getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.USER_CHAT_MESSAGE_DELETE.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.USER_CHAT_MESSAGE_DELETE.toFullURL(), body);
     }
 }

--- a/src/main/java/snw/kookbc/impl/message/TextChannelMessageImpl.java
+++ b/src/main/java/snw/kookbc/impl/message/TextChannelMessageImpl.java
@@ -46,7 +46,7 @@ public class TextChannelMessageImpl extends MessageImpl implements TextChannelMe
                 .put("msg_id", getId())
                 .put("emoji", emoji.getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_ADD.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_ADD.toFullURL(), body);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class TextChannelMessageImpl extends MessageImpl implements TextChannelMe
                 .put("msg_id", getId())
                 .put("emoji", emoji.getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_REMOVE.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_REMOVE.toFullURL(), body);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class TextChannelMessageImpl extends MessageImpl implements TextChannelMe
                 .put("emoji", emoji.getId())
                 .put("user_id", user.getId())
                 .build();
-        client.getNetworkClient().post(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_REMOVE.toFullURL(), body);
+        client.getNetworkClient().postContent(HttpAPIRoute.CHANNEL_MESSAGE_REACTION_REMOVE.toFullURL(), body);
     }
 
     @Override


### PR DESCRIPTION
…all the message.sendReaction() and message.removeReaction

# KookBC Pull Request

您的 Fork 仓库地址:https://github.com/xiaoACE6716/KookBC

## KookBC 程序的漏洞修复

修复机器人在进行sendReaction与removeReaction时的问题
Use NetworkClient.postContent() instead of NetworkClient.post() in all the message.sendReaction() and message.removeReaction()

