### PR TITLE
Refactor/commandmap

### DIFF
--- a/src/main/java/snw/kookbc/impl/command/CommandManagerImpl.java
+++ b/src/main/java/snw/kookbc/impl/command/CommandManagerImpl.java
@@ -38,13 +38,7 @@ import static snw.kookbc.util.Util.toEnglishNumOrder;
 
 public class CommandManagerImpl implements CommandManager {
     private final KBCClient client;
-    // The following comments will tell you the difference between the following two member variables.
-    // For example, there is a command called "hello"
-    // Its prefixes are "/", "."
-    // So the commands Map will contain a key called "hello"
-    // But the commandWithPrefix Map will contain two keys, "/hello", ".hello"
-    private final Map<String, WrappedCommand> commands = new ConcurrentHashMap<>();
-    private final Map<String, WrappedCommand> commandWithPrefix = new ConcurrentHashMap<>();
+    protected final SimpleCommandMap commandMap = new SimpleCommandMap();
     private final Map<Class<?>, Function<String, ?>> parsers = new ConcurrentHashMap<>();
 
     public CommandManagerImpl(KBCClient client) {
@@ -60,10 +54,9 @@ public class CommandManagerImpl implements CommandManager {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("The command from '" + plugin.getDescription().getName() + "' plugin does not meet our standards.", e);
         }
-        Collection<String> allCommandHeader = getAllCommandHeader(command);
-        WrappedCommand result = new WrappedCommand(command, plugin);
-        commands.put(command.getRootName(), result);
-        allCommandHeader.forEach(i -> commandWithPrefix.put(i, result));
+        commandMap.register(plugin, command);
+
+
     }
 
     // Throw exception if the provided command can NOT be registered
@@ -76,7 +69,7 @@ public class CommandManagerImpl implements CommandManager {
                 .map(i -> i + command.getRootName())
                 .collect(Collectors.toList());
         for (String head : duplicateNameWithPrefix) {
-            WrappedCommand cmd = commandWithPrefix.get(head);
+            WrappedCommand cmd = getCommandWithPrefix(head);
             if (cmd != null) {
                 throw new IllegalArgumentException("The command with the same (prefix + root name) result has been found in a command from '" + cmd.getPlugin().getDescription().getName() + "' plugin.");
             }
@@ -102,24 +95,14 @@ public class CommandManagerImpl implements CommandManager {
 
     // Return the conflict command object if detected confliction, otherwise null.
     private WrappedCommand checkAliasWithPrefix(String prefix, Collection<String> aliases) {
+        final Map<String, WrappedCommand> view = commandMap.getView(true);
         for (String alias : aliases) {
             String head = prefix + alias;
-            if (commandWithPrefix.containsKey(head)) {
-                return commandWithPrefix.get(head);
+            if (view.containsKey(head)) {
+                return view.get(head);
             }
         }
         return null;
-    }
-
-    private Collection<String> getAllCommandHeader(JKookCommand command) {
-        Collection<String> result = new ArrayList<>(command.getPrefixes().size() * (command.getAliases().size() + 1));
-        for (String prefix : command.getPrefixes()) {
-            result.add(prefix + command.getRootName());
-            for (String alias : command.getAliases()) {
-                result.add(prefix + alias);
-            }
-        }
-        return result;
     }
 
     @Override
@@ -289,26 +272,30 @@ public class CommandManagerImpl implements CommandManager {
         return true; // ok, the command is ok, so we can return true.
     }
 
+    public SimpleCommandMap getCommandMap() {
+        return commandMap;
+    }
+
     public Set<JKookCommand> getCommandSet() {
-        return commands.values().stream().map(WrappedCommand::getCommand).collect(Collectors.toSet());
+        return commandMap.getView(false).values().stream().map(WrappedCommand::getCommand).collect(Collectors.toSet());
     }
 
     public Map<String, WrappedCommand> getCommands() {
-        return commands;
+        return commandMap.getView(false);
     }
 
     public Map<String, WrappedCommand> getCommandWithPrefix() {
-        return commandWithPrefix;
+        return commandMap.getView(true);
     }
 
     public WrappedCommand getCommand(String rootName) {
         if (rootName.isEmpty()) return null; // do not execute invalid for loop!
-        return commands.get(rootName);
+        return commandMap.getView(false).get(rootName);
     }
 
     protected WrappedCommand getCommandWithPrefix(String cmdHeader) {
         if (cmdHeader.isEmpty()) return null; // do not execute invalid for loop!
-        return commandWithPrefix.get(cmdHeader);
+        return commandMap.getView(true).get(cmdHeader);
     }
 
     protected Object[] processArguments(JKookCommand command, List<String> rawArgs) {

--- a/src/main/java/snw/kookbc/impl/command/CommandManagerImpl.java
+++ b/src/main/java/snw/kookbc/impl/command/CommandManagerImpl.java
@@ -38,11 +38,16 @@ import static snw.kookbc.util.Util.toEnglishNumOrder;
 
 public class CommandManagerImpl implements CommandManager {
     private final KBCClient client;
-    protected final SimpleCommandMap commandMap = new SimpleCommandMap();
+    protected final SimpleCommandMap commandMap;
     private final Map<Class<?>, Function<String, ?>> parsers = new ConcurrentHashMap<>();
 
     public CommandManagerImpl(KBCClient client) {
+        this(client, new SimpleCommandMap());
+    }
+
+    public CommandManagerImpl(KBCClient client, SimpleCommandMap commandMap) {
         this.client = client;
+        this.commandMap = commandMap;
         registerInternalParsers();
     }
 

--- a/src/main/java/snw/kookbc/impl/command/SimpleCommandMap.java
+++ b/src/main/java/snw/kookbc/impl/command/SimpleCommandMap.java
@@ -1,0 +1,51 @@
+/*
+ *     KookBC -- The Kook Bot Client & JKook API standard implementation for Java.
+ *     Copyright (C) 2022 - 2023 KookBC contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package snw.kookbc.impl.command;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+
+import snw.jkook.command.JKookCommand;
+import snw.jkook.plugin.Plugin;
+
+// A simple command map as the storage of the command objects. // TODO implement methods
+public class SimpleCommandMap {
+    
+    public void register(Plugin plugin, JKookCommand command) throws IllegalArgumentException {
+
+    }
+
+    public void unregister(JKookCommand command) {
+
+    }
+
+    public void unregisterAll(Plugin plugin) {
+
+    }
+
+    public Map<String, WrappedCommand> getView(boolean withPrefix) {
+        return null;
+    }
+
+    public @Nullable JKookCommand getByRootName(String head, boolean withPrefix) {
+        return null;
+    }
+
+}

--- a/src/main/java/snw/kookbc/impl/command/SimpleCommandMap.java
+++ b/src/main/java/snw/kookbc/impl/command/SimpleCommandMap.java
@@ -18,6 +18,7 @@
 
 package snw.kookbc.impl.command;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -28,19 +29,16 @@ import org.jetbrains.annotations.Nullable;
 import snw.jkook.command.JKookCommand;
 import snw.jkook.plugin.Plugin;
 
-import static snw.kookbc.util.Util.ensurePluginEnabled;
-
 // A simple command map as the storage of the command objects. // TODO implement methods
 public class SimpleCommandMap {
     protected final Map<String, WrappedCommand> commandsWithoutPrefix = new ConcurrentHashMap<>();
     protected final Map<String, WrappedCommand> commandsWithPrefix = new ConcurrentHashMap<>();
     protected final Map<String, WrappedCommand> commandsWithoutPrefixView = Collections.unmodifiableMap(commandsWithoutPrefix);
     protected final Map<String, WrappedCommand> commandsWithPrefixView = Collections.unmodifiableMap(commandsWithPrefix);
-    
-    public void register(Plugin plugin, JKookCommand command) throws IllegalArgumentException {
-        ensurePluginEnabled(plugin);
-        checkCommand(command);
 
+    protected SimpleCommandMap() {}
+    
+    public void register(Plugin plugin, JKookCommand command) {
         WrappedCommand wrapped = new WrappedCommand(command, plugin);
         
         commandsWithoutPrefix.put(command.getRootName(), wrapped);
@@ -72,12 +70,16 @@ public class SimpleCommandMap {
         return null;
     }
 
-    protected void checkCommand(JKookCommand command) throws IllegalArgumentException {
-        // TODO
-    }
 
     protected static Collection<String> createHeaders(JKookCommand command) {
-        return null; // TODO
+        Collection<String> result = new ArrayList<>(command.getPrefixes().size() * (command.getAliases().size() + 1));
+        for (String prefix : command.getPrefixes()) {
+            result.add(prefix + command.getRootName());
+            for (String alias : command.getAliases()) {
+                result.add(prefix + alias);
+            }
+        }
+        return result;
     }
 
 }

--- a/src/main/java/snw/kookbc/impl/plugin/SimplePluginManager.java
+++ b/src/main/java/snw/kookbc/impl/plugin/SimplePluginManager.java
@@ -165,8 +165,7 @@ public class SimplePluginManager implements PluginManager {
         client.getCore().getScheduler().cancelTasks(plugin);
         client.getCore().getEventManager().unregisterAllHandlers(plugin);
         // unregister commands
-        ((CommandManagerImpl) client.getCore().getCommandManager()).getCommands().entrySet().removeIf(next -> Objects.equals(next.getValue().getPlugin(), plugin));
-        ((CommandManagerImpl) client.getCore().getCommandManager()).getCommandWithPrefix().entrySet().removeIf(i -> Objects.equals(i.getValue().getPlugin(), plugin));
+        ((CommandManagerImpl) client.getCore().getCommandManager()).getCommandMap().unregisterAll(plugin);
         try {
             plugin.setEnabled(false);
         } catch (Throwable e) {


### PR DESCRIPTION
# KookBC Pull Request

## 增加的新内容

增加了 SimpleCommandMap 。以用于将命令对象的存储从 CommandManagerImpl 中抽离。