### PR TITLE
Make Plugin's classloader always SimplePluginClassLoader

### DIFF
--- a/src/main/java/snw/kookbc/impl/plugin/SimplePluginClassLoader.java
+++ b/src/main/java/snw/kookbc/impl/plugin/SimplePluginClassLoader.java
@@ -179,6 +179,12 @@ public class SimplePluginClassLoader extends PluginClassLoader {
     @Override
     public void close() throws IOException {
         INSTANCES.remove(this);
+        for (Class<?> clazz : cache.values()) {
+            if (ConfigurationSerializable.class.isAssignableFrom(clazz)) {
+                //noinspection unchecked
+                ConfigurationSerialization.unregisterClass((Class<? extends ConfigurationSerializable>) clazz);
+            }
+        }
         super.close();
     }
 }

--- a/src/main/java/snw/kookbc/impl/plugin/SimplePluginClassLoader.java
+++ b/src/main/java/snw/kookbc/impl/plugin/SimplePluginClassLoader.java
@@ -22,6 +22,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import snw.jkook.Core;
+import snw.jkook.config.serialization.ConfigurationSerializable;
+import snw.jkook.config.serialization.ConfigurationSerialization;
 import snw.jkook.plugin.Plugin;
 import snw.jkook.plugin.PluginClassLoader;
 import snw.jkook.plugin.PluginDescription;
@@ -95,9 +97,8 @@ public class SimplePluginClassLoader extends PluginClassLoader {
         if (this.findLoadedClass(mainClassName) != null) {
             throw new IllegalArgumentException("The main class defined in plugin.yml has already been defined in the VM.");
         } else {
-            if (parentClassLoader == null) {
-                super.addURL(file.toURI().toURL());
-            } else {
+            super.addURL(file.toURI().toURL());
+            if (parentClassLoader != null) {
                 parentClassLoader.addURL(file.toURI().toURL());
             }
             Class<?> loadClass = this.loadClass(mainClassName, true);
@@ -112,10 +113,7 @@ public class SimplePluginClassLoader extends PluginClassLoader {
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        if (parentClassLoader == null) {
-            return super.loadClass(name, resolve);
-        }
-        return parentClassLoader.loadClass(name, resolve);
+        return super.loadClass(name, resolve);
     }
 
     @Override
@@ -128,7 +126,7 @@ public class SimplePluginClassLoader extends PluginClassLoader {
             return cache.get(name);
         }
         try {
-            Class<?> result = parentClassLoader == null ? super.findClass(name) : parentClassLoader.findClass(name);
+            Class<?> result = /*parentClassLoader == null ? */super.findClass(name)/* : parentClassLoader.findClass(name)*/;
             if (result != null) {
                 cache.put(name, result);
                 return result;
@@ -148,6 +146,13 @@ public class SimplePluginClassLoader extends PluginClassLoader {
     }
 
     protected Class<?> loadFromOther(String name) throws ClassNotFoundException {
+        try {
+            Class<?> clazz = parentClassLoader.findClass(name);
+            if (clazz != null) {
+                return clazz;
+            }
+        } catch (ClassNotFoundException ignored) {
+        }
         for (SimplePluginClassLoader classLoader : INSTANCES) {
             if (classLoader == null) {
                 // Suggested by ChatGPT:

--- a/src/main/java/snw/kookbc/impl/plugin/SimplePluginClassLoader.java
+++ b/src/main/java/snw/kookbc/impl/plugin/SimplePluginClassLoader.java
@@ -126,7 +126,7 @@ public class SimplePluginClassLoader extends PluginClassLoader {
             return cache.get(name);
         }
         try {
-            Class<?> result = /*parentClassLoader == null ? */super.findClass(name)/* : parentClassLoader.findClass(name)*/;
+            Class<?> result = super.findClass(name);
             if (result != null) {
                 cache.put(name, result);
                 return result;

--- a/src/main/java/snw/kookbc/impl/plugin/SimplePluginManager.java
+++ b/src/main/java/snw/kookbc/impl/plugin/SimplePluginManager.java
@@ -226,13 +226,13 @@ public class SimplePluginManager implements PluginManager {
         } catch (Throwable e) {
             plugin.getLogger().error("Exception occurred when we are disabling this plugin", e);
         }
-//        if (plugin.getClass().getClassLoader() instanceof SimplePluginClassLoader) {
-//            try {
-//                ((SimplePluginClassLoader) plugin.getClass().getClassLoader()).close();
-//            } catch (IOException e) {
-//                logger.error("Unexpected IOException while we're attempting to close the PluginClassLoader.", e);
-//            }
-//        }
+        if (plugin.getClass().getClassLoader() instanceof SimplePluginClassLoader) {
+            try {
+                ((SimplePluginClassLoader) plugin.getClass().getClassLoader()).close();
+            } catch (IOException e) {
+                logger.error("Unexpected IOException while we're attempting to close the PluginClassLoader.", e);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/snw/kookbc/launcher/Launcher.java
+++ b/src/main/java/snw/kookbc/launcher/Launcher.java
@@ -13,7 +13,7 @@ public abstract class Launcher {
         return launcher;
     }
 
-    public void onSetup() {
+    public final void onSetup() {
         if (instance() != this) {
             return;
         }


### PR DESCRIPTION
# KookBC Pull Request

Plugin的ClassLoader将永远是SimplePluginClassLoader，在这之前在mixin模式下它是LaunchClassLoader

## KookBC 程序的漏洞修复

如果您的 Fork 修复了某个 Issue 所描述的问题，请在这里提及那个 Issue 。

#61 
