### PR TITLE
Fix bug caused by quote field being an empty string

### DIFF
--- a/src/main/java/snw/kookbc/impl/HttpAPIImpl.java
+++ b/src/main/java/snw/kookbc/impl/HttpAPIImpl.java
@@ -303,9 +303,12 @@ public class HttpAPIImpl implements HttpAPI {
         long timeStamp = get(object, "create_at").getAsLong();
         PrivateMessage quote = null;
         if (has(object, "quote")) {
-            final JsonObject rawQuote = get(object, "quote").getAsJsonObject();
-            final String quoteId = get(rawQuote, "id").getAsString();
-            quote = getPrivateMessage(user, quoteId);
+            JsonElement rawQuote = get(object, "quote");
+            if (!rawQuote.isJsonNull() && !rawQuote.getAsString().trim().isEmpty()) {
+                final JsonObject quoteObj = rawQuote.getAsJsonObject();
+                final String quoteId = get(quoteObj, "id").getAsString();
+                quote = getPrivateMessage(user, quoteId);
+            }
         }
         return new PrivateMessageImpl(client, id, user, component, timeStamp, quote);
     }

--- a/src/main/java/snw/kookbc/impl/HttpAPIImpl.java
+++ b/src/main/java/snw/kookbc/impl/HttpAPIImpl.java
@@ -304,10 +304,16 @@ public class HttpAPIImpl implements HttpAPI {
         PrivateMessage quote = null;
         if (has(object, "quote")) {
             JsonElement rawQuote = get(object, "quote");
-            if (!rawQuote.isJsonNull() && !rawQuote.getAsString().trim().isEmpty()) {
-                final JsonObject quoteObj = rawQuote.getAsJsonObject();
-                final String quoteId = get(quoteObj, "id").getAsString();
-                quote = getPrivateMessage(user, quoteId);
+            if (rawQuote.isJsonObject()) {
+                if (!rawQuote.isJsonNull()) {
+                    final JsonObject quoteObj = rawQuote.getAsJsonObject();
+                    final String quoteId = get(quoteObj, "id").getAsString();
+                    quote = getPrivateMessage(user, quoteId);
+                }
+            }else {
+                if (rawQuote.getAsString().trim().isEmpty()) {
+                    return new PrivateMessageImpl(client, id, user, component, timeStamp, quote);
+                }
             }
         }
         return new PrivateMessageImpl(client, id, user, component, timeStamp, quote);


### PR DESCRIPTION
修复[#30](https://github.com/SNWCreations/KookBC/issues/81) 
原因: KOOK API返回的Json中，当不存在回复引用时，quote字段的值可能为 `null` 或 `""` 