### PR TITLE
Add an empty listener to update the channel's information as it should

### DIFF
--- a/src/main/java/snw/kookbc/impl/KBCClient.java
+++ b/src/main/java/snw/kookbc/impl/KBCClient.java
@@ -40,6 +40,7 @@ import snw.kookbc.impl.console.Console;
 import snw.kookbc.impl.entity.builder.EntityBuilder;
 import snw.kookbc.impl.entity.builder.MessageBuilder;
 import snw.kookbc.impl.event.EventFactory;
+import snw.kookbc.impl.event.internal.ChannelInfoUpdateListener;
 import snw.kookbc.impl.event.internal.UserClickButtonListener;
 import snw.kookbc.impl.network.HttpAPIRoute;
 import snw.kookbc.impl.network.NetworkClient;
@@ -536,6 +537,9 @@ public class KBCClient {
                 .register(getInternalPlugin());
         this.core.getEventManager()
                 .registerHandlers(this.internalPlugin, new UserClickButtonListener(this));
+        this.core.getEventManager()
+                .registerHandlers(this.internalPlugin, new ChannelInfoUpdateListener());
+
     }
 
     public CommandManager getCommandManager() {

--- a/src/main/java/snw/kookbc/impl/event/internal/ChannelInfoUpdateListener.java
+++ b/src/main/java/snw/kookbc/impl/event/internal/ChannelInfoUpdateListener.java
@@ -1,0 +1,14 @@
+package snw.kookbc.impl.event.internal;
+
+import snw.jkook.event.EventHandler;
+import snw.jkook.event.Listener;
+import snw.jkook.event.channel.ChannelInfoUpdateEvent;
+
+public class ChannelInfoUpdateListener implements Listener {
+
+    @EventHandler(internal = true)
+    public void event(ChannelInfoUpdateEvent event) {
+        // An empty listener that updates the channel's information as it should
+    }
+
+}


### PR DESCRIPTION
如题所示，如果没有监听器监听 ChannelUpdateEvent ，频道信息不会得到正确的更新，所以我添加了一个空的监听器