### PR TITLE
在 friend/handle-request 中返回的 data 字段内容不是 JsonObject

### DIFF
--- a/src/main/java/snw/kookbc/impl/network/NetworkClient.java
+++ b/src/main/java/snw/kookbc/impl/network/NetworkClient.java
@@ -18,6 +18,7 @@
 
 package snw.kookbc.impl.network;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import okhttp3.*;
@@ -68,7 +69,12 @@ public class NetworkClient {
     }
 
     public JsonObject post(String fullUrl, Map<?, ?> body) {
-        return checkResponse(JsonParser.parseString(postContent(fullUrl, body)).getAsJsonObject()).getAsJsonObject("data");
+        JsonElement element = checkResponse(JsonParser.parseString(postContent(fullUrl, body)).getAsJsonObject()).get("data");
+        if (element instanceof JsonObject) {
+            return element.getAsJsonObject();
+        } else {
+            return null;
+        }
     }
 
     public String getRawContent(String fullUrl) {


### PR DESCRIPTION
如题所示，因为HttpAPIImpl#handleFriendRequest方法的返回值是void，所以加个判断让他返回null而不会报ClassCastException(大概看了下其他接口的 data 字段都是 JsonObject)